### PR TITLE
Require an empty line after variable declarations

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -52,6 +52,10 @@ module.exports = {
     // http://eslint.org/docs/rules/linebreak-style
     'linebreak-style': ['error', 'unix'],
 
+    // require an empty line after variable declarations
+    // http://eslint.org/docs/rules/newline-after-var
+    'newline-after-var': ['error', 'always'],
+
     // disallow Array constructors
     // http://eslint.org/docs/rules/no-array-constructor
     'no-array-constructor': ['error'],


### PR DESCRIPTION
@Ticketfly/frontenders 

This would help prevent code like this:

```js
const greet = 'hello';
const NAME = 'world';
console.log(greet, NAME);
askQuestion();
``` 

and instead bring some sanity and cleanliness to spacing:

```js
const greet = 'hello';
const NAME = 'world';

console.log(greet, NAME);
askQuestion();
```