### PR TITLE
More-refined rule for quotes

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -67,8 +67,11 @@ module.exports = {
     // disallow trailing whitespace at the end of lines
     'no-trailing-spaces': 'error',
 
-    // specify whether double or single quotes should be used
-    quotes: ['error', 'single', { avoidEscape: true }],
+    // enforce the consistent use of single quotes, while also allowing
+    // deviations where an escape character would be needed otherwise, and
+    // allowing backticks for template-literals
+    // http://eslint.org/docs/rules/quotes
+    quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
 
     // require semicolons at the end of statements
     // http://eslint.org/docs/rules/semi


### PR DESCRIPTION
@Ticketfly/frontenders 

This change enforces the consistent use of single quotes, while also allowing
deviations where an escape character would be needed otherwise, and
allowing backticks for template-literals.