### PR TITLE
allow trailling spaces on empty lines

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -65,7 +65,8 @@ module.exports = {
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
 
     // disallow trailing whitespace at the end of lines
-    'no-trailing-spaces': 'error',
+    // http://eslint.org/docs/rules/no-trailing-spaces#skipblanklines
+    'no-trailing-spaces': ['error', { skipBlankLines: true }],
 
     // specify whether double or single quotes should be used
     quotes: ['error', 'single', { avoidEscape: true }],


### PR DESCRIPTION
@BrianSipple I opened this PR to see if we are ok to allow trailing spaces on empty lines, refer to http://eslint.org/docs/rules/no-trailing-spaces#skipblanklines. 
I feel it makes easy when typing "enter" to create a new line and have the alignment, without having to remove its spaces.

cc @Ticketfly/frontenders 