### PR TITLE
define rules around comment syntax

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -38,7 +38,8 @@ module.exports = {
 
     // require immediate function invocation to be wrapped in parentheses
     // http://eslint.org/docs/rules/wrap-iife.html
-    'wrap-iife': ['error', 'outside'],  // use this style: ``` var x = (function () { return { y: 1 };}()); ```,
+    // HINT: use this style: `var x = (function () { return { y: 1 };}());`,
+    'wrap-iife': ['error', 'outside'],
 
     // require or disallow Yoda conditions
     yoda: 'error'

--- a/rules/strict-mode.js
+++ b/rules/strict-mode.js
@@ -7,8 +7,9 @@
  */
 module.exports = {
   rules: {
-    // require or disallow strict mode directives
+    // disallow strict mode directives
+    // (we prefer ECMAScript2015+ module environment, where strict mode is already implied)
     // http://eslint.org/docs/rules/strict#rule-details
-    strict: ['error', 'never']  // we prefer ECMAScript2015+ module environment, where strict mode is already implied
+    strict: ['error', 'never']
   }
 };

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -48,9 +48,28 @@ module.exports = {
       }
     }],
 
+    //  enforces line comments only above code, in its own line.
+    // http://eslint.org/docs/rules/line-comment-position
+    'line-comment-position': ['error', { position: 'above' }],
+
     // disallow mixed 'LF' and 'CRLF' as linebreaks
     // http://eslint.org/docs/rules/linebreak-style
     'linebreak-style': ['error', 'unix'],
+
+    // require empty lines around comments
+    // http://eslint.org/docs/rules/lines-around-comment
+    'lines-around-comment': ['error', {
+      beforeBlockComment: true,
+      afterBlockComment: false,
+      beforeLineComment: true,
+      afterLineComment: false,
+      allowBlockStart: true,
+      allowBlockEnd: false,
+      allowObjectStart: true,
+      allowObjectEnd: false,
+      allowArrayStart: true,
+      allowArrayEnd: false
+    }],
 
     // require an empty line after variable declarations
     // http://eslint.org/docs/rules/newline-after-var
@@ -59,6 +78,10 @@ module.exports = {
     // disallow Array constructors
     // http://eslint.org/docs/rules/no-array-constructor
     'no-array-constructor': ['error'],
+
+    // disallow inline comments after code
+    // http://eslint.org/docs/rules/no-inline-comments
+    'no-inline-comments': 'error',
 
     // disallow use of unary operators, ++ and --
     // http://eslint.org/docs/rules/no-plusplus
@@ -75,6 +98,18 @@ module.exports = {
     semi: ['error', 'always'],
 
     // require or disallow space before blocks
-    'space-before-blocks': 'error'
+    'space-before-blocks': 'error',
+
+    // enforce consistent spacing after the // or /* in a comment
+    // http://eslint.org/docs/rules/spaced-comment
+    'spaced-comment': ['error', 'always', {
+      line: {
+        exceptions: ['-', '+']
+      },
+      block: {
+        exceptions: ['-', '+'],
+        balanced: false
+      }
+    }]
   }
 };


### PR DESCRIPTION
@Ticketfly/frontenders 

This PR defines settings for the `line-comment-position`, `lines-around-comment`, `no-inline-comments`, and `spaced-comment` rules to help clean up the way comments are written.

The main points would be placing comments on their own lines, and including a space after the `//` or `/*`.