### PR TITLE
Disallow reassigning function parameters

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -36,6 +36,10 @@ module.exports = {
     // disallow use of new operator when not part of the assignment or comparison
     'no-new': 'error',
 
+    // disallow reassigning function parameters
+    // http://eslint.org/docs/rules/no-param-reassign
+    'no-param-reassign': ['error'],
+
     // require immediate function invocation to be wrapped in parentheses
     // http://eslint.org/docs/rules/wrap-iife.html
     // HINT: use this style: `var x = (function () { return { y: 1 };}());`,


### PR DESCRIPTION
@Ticketfly/frontenders 

During PRs, I've encountered several cases where we're reassigning function parameters and it's actually a code smell where, instead, we should ensuring that there's more control over the argument passed to the function in the first place. 

Enforcing this rule will help us detect and fix those instances automatically.