### PR TITLE
turn off `no-inline-comments`

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -81,7 +81,7 @@ module.exports = {
 
     // disallow inline comments after code
     // http://eslint.org/docs/rules/no-inline-comments
-    'no-inline-comments': 'error',
+    'no-inline-comments': 'off',
 
     // disallow use of unary operators, ++ and --
     // http://eslint.org/docs/rules/no-plusplus


### PR DESCRIPTION
@Ticketfly/frontenders 

This would be a breaking change, and so I'd cut a `2.0.0` after merging.

#7 made some additions around comments, but I didn't put enough consideration into `no-inline-comments`.

I think it can be really beneficial -- and clean -- to use them occasionally for commenting out unused function parameters that _may_ become useful to the caller in the future:

```js
onSeatClicked(ev /* , seatModel */) {
  ev.preventDefault();

  return get(this, 'handleClick')();
}
```

Unfortunately, the current `no-inline-comments` rule offers no special configuration to allow _only_ this style, so I'd rather just turn it off.